### PR TITLE
じぇきるの無視ファイルを追加

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -1,0 +1,5 @@
+exclude:
+    - Gemfile
+    - Gemfile.lock
+    - docker-compose.yaml
+    - \#*


### PR DESCRIPTION
- Gemfileとかdocker-compose.yamlを無視
- ドットスタートやアンダーバースタートはデフォルトで無視されるようだ

https://idratherbewriting.com/documentation-theme-jekyll/mydoc_exluding_files.html