### PR TITLE
Dockerの起動を早くしようとした

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
 [**]
-indent_size = 4
+indent_size = 2
 insert_final_newline = true
+
+[*.html]
+indent_size = 4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,9 @@ services:
     image: jekyll/jekyll:pages
     command: jekyll serve --livereload
     volumes:
-      - $PWD:/srv/jekyll
+      - .:/srv/jekyll:cached
+      - /srv/jekyll/.git        # exclude
+      - /srv/jekyll/_site       # exclude
     ports:
       - 4000:4000
       - 35729:35729

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,8 +5,9 @@ services:
     command: jekyll serve --livereload
     volumes:
       - .:/srv/jekyll:cached
-      - /srv/jekyll/.git        # exclude
-      - /srv/jekyll/_site       # exclude
+    tmpfs:
+      - /srv/jekyll/.git
+      - /srv/jekyll/_site
     ports:
       - 4000:4000
       - 35729:35729


### PR DESCRIPTION
早くならなかった。

- 起動時のjekyllのメッセージを見ると、更新前も後も3s足らずくらい。
- `bundle exec jekyll s -l`で起動しても2.5sくらいなので、誤差

### やったこと

- Dockerマウントにcachedオプションをつけた
- _siteを除外した
  - 書き込みは権限などのトラブルが多いので、残さない
- いらないフォルダのマウントを除外した
- editorconfigを更新
  - 設定を用意してもすぐにインデントがバラバラになる、人間は愚か。